### PR TITLE
Fix log insertion with JSON metadata

### DIFF
--- a/internal/api/logging.go
+++ b/internal/api/logging.go
@@ -157,6 +157,13 @@ func PostLog(logEntry *models.Log) error {
 		logEntry.Metadata = &emptyJSON
 	}
 
+	var metadataBytes []byte
+	if logEntry.Metadata != nil {
+		metadataBytes = *logEntry.Metadata
+	} else {
+		metadataBytes = []byte("{}")
+	}
+
 	query := `INSERT INTO logs 
 		(service_name, log_level, message, timestamp, trace_id, span_id, metadata) 
 		VALUES ($1, $2, $3, $4, $5, $6, $7) 
@@ -171,7 +178,7 @@ func PostLog(logEntry *models.Log) error {
 		logEntry.Timestamp,
 		logEntry.TraceID,
 		logEntry.SpanID,
-		logEntry.Metadata,
+		metadataBytes,
 	).Scan(&logEntry.ID)
 
 	if err != nil {


### PR DESCRIPTION
## Summary
- fix `PostLog` to convert JSON metadata into bytes for insertion

## Testing
- `go vet ./...` *(fails: unable to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_6850d1e6d32483318a550fd2e0fb10b4