### PR TITLE
Add Grafana log visualization UI

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,5 +33,21 @@ services:
       RATE_LIMIT_REQUESTS: ${RATE_LIMIT_REQUESTS}
       RATE_LIMIT_WINDOW: ${RATE_LIMIT_WINDOW}
 
+  grafana:
+    image: grafana/grafana:10.4.0
+    container_name: go_insight_grafana
+    ports:
+      - "3000:3000"
+    depends_on:
+      - postgres
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+    volumes:
+      - ./provisioning/grafana/datasources:/etc/grafana/provisioning/datasources
+      - ./provisioning/grafana/dashboards:/etc/grafana/provisioning/dashboards
+      - grafana_data:/var/lib/grafana
+
 volumes:
   pgdata:
+  grafana_data:

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,6 +67,7 @@ cp .env.example .env
 ```bash
 # Start the entire stack
 docker-compose up -d --build
+# This also starts a Grafana instance on port 3000
 
 # Verify health
 curl http://localhost:8001/health
@@ -111,6 +112,10 @@ docker-compose logs go-insight
 
 # View database logs
 docker-compose logs postgres
+
+# Access Grafana dashboard
+# Default credentials: admin / admin
+http://localhost:3000
 
 # Stop all services
 docker-compose down

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -587,6 +587,20 @@ require (
 - Role-based access control (RBAC)
 **Future**: OAuth2 integration for enterprise environments
 
+### 5. Log Visualization UI
+**Decision**: Integrate Grafana for log dashboards instead of building a custom UI in the short term.
+
+**Why Grafana**:
+- Mature visualization platform with built-in PostgreSQL support
+- Ready-made dashboarding capabilities reduce development time
+- Easily extensible for metrics and traces
+
+**Alternatives Considered**:
+- **Custom React UI**: Full control over design but requires significant effort
+- **Kibana**: Another log UI option, but heavier stack and less integrated with existing plans
+
+Grafana can be deployed alongside Go-Insight via Docker Compose and connects directly to the PostgreSQL database. A custom UI remains possible in the future if specialized features are needed.
+
 ## Testing Strategy
 
 ### Unit Testing

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -62,7 +62,8 @@ Go-Insight is an observability platform designed to collect, store, and visualiz
 ## Phase 3: User Interface & Visualization (3-4 months)
 
 ### Dashboard Development
-- **Web UI framework** selection and setup
+- **Grafana dashboards** for log visualization (initial implementation)
+- **Web UI framework** selection and setup for future custom features
 - **Log viewer** with real-time search and filtering
 - **Metrics visualization** with time-series charts and graphs
 - **Trace visualization** with span relationships and timing

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -540,6 +540,10 @@ try {
 }
 ```
 
+## Visualizing Logs
+
+After starting the Docker stack, Grafana runs on `http://localhost:3000` with default credentials `admin/admin`. The provided dashboard shows recent log entries from the `logs` table. You can customize queries or create new dashboards to fit your needs.
+
 ## Performance Tips
 
 1. **Batch Operations**: Group multiple log entries when possible

--- a/provisioning/grafana/dashboards/dashboard.yaml
+++ b/provisioning/grafana/dashboards/dashboard.yaml
@@ -1,0 +1,8 @@
+apiVersion: 1
+providers:
+  - name: 'default'
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    options:
+      path: /var/lib/grafana/dashboards

--- a/provisioning/grafana/dashboards/logs.json
+++ b/provisioning/grafana/dashboards/logs.json
@@ -1,0 +1,25 @@
+{
+  "dashboard": {
+    "title": "Go-Insight Logs",
+    "panels": [
+      {
+        "type": "table",
+        "title": "Recent Logs",
+        "datasource": "GoInsight",
+        "targets": [
+          {
+            "format": "table",
+            "rawSql": "SELECT timestamp, service_name, log_level, message FROM logs ORDER BY timestamp DESC LIMIT 50",
+            "refId": "A"
+          }
+        ],
+        "options": {
+          "showHeader": true
+        },
+        "gridPos": {"x": 0, "y": 0, "w": 24, "h": 8}
+      }
+    ],
+    "schemaVersion": 37,
+    "version": 1
+  }
+}

--- a/provisioning/grafana/datasources/datasource.yaml
+++ b/provisioning/grafana/datasources/datasource.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+datasources:
+  - name: GoInsight
+    type: postgres
+    access: proxy
+    url: postgres:5432
+    database: ${DB_NAME}
+    user: ${DB_USER}
+    secureJsonData:
+      password: ${DB_PASS}
+    jsonData:
+      sslmode: disable


### PR DESCRIPTION
## Summary
- add Grafana service with datasource provisioning
- document how to use Grafana to view logs
- outline architecture decision for Grafana vs custom UI

## Testing
- `go test ./...` *(fails: proxy.golang.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68713fbb09a8833183c540a92b41d9fe